### PR TITLE
Restrict scipy version; breaking changes in 1.3.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='duckietown_rl',
                         'torch',
                         'numpy',
                         'matplotlib',
-                        'scipy']
+                        'scipy<=1.2.1']
       )


### PR DESCRIPTION
There were breaking changes in scipy 1.3.0 w.r.t scipy.misc module (no more [imresize](https://docs.scipy.org/doc/scipy-1.3.0/reference/misc.html)).