### PR TITLE
seeds arg in test_cnn.py

### DIFF
--- a/duckietown_rl/args.py
+++ b/duckietown_rl/args.py
@@ -23,7 +23,7 @@ def get_ddpg_args_train():
 
 def get_ddpg_args_test():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--seed", default=0, type=int)  # Sets Gym, PyTorch and Numpy seeds
+    parser.add_argument("--seed", default=0, type=int)  # Inform the test what seed was used in training
     parser.add_argument("--experiment", default=2, type=int)
     
     return parser.parse_args()

--- a/duckietown_rl/scripts/test_cnn.py
+++ b/duckietown_rl/scripts/test_cnn.py
@@ -2,21 +2,22 @@ import gym
 import gym_duckietown
 import torch
 from ddpg import DDPG
+from args import get_ddpg_args_test
 from utils import evaluate_policy
 from wrappers import NormalizeWrapper, ImgWrapper, \
     DtRewardWrapper, ActionWrapper, ResizeWrapper
 from env import launch_env
 import numpy as np
 
-seed = 1
 policy_name = "DDPG"
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
+args = get_ddpg_args_test()
 
 file_name = "{}_{}".format(
     policy_name,
-    seed
+    args.seed
 )
 
 env = launch_env()


### PR DESCRIPTION
No need to modify test_cnn.py to set the seed; user can just pass it in as argument.

Corresponding change in documentation incoming.